### PR TITLE
Add static sequence support

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -5,6 +5,7 @@ http
 https
 instructables
 microcontrollers
+millis
 portb
 portc
 portd

--- a/led-flipflop-extender/decoder.ino
+++ b/led-flipflop-extender/decoder.ino
@@ -1,21 +1,3 @@
-// The number of the decoder input pins.
-const int D_PINS_NUMBER = 3;
-
-// The number of flipFlop chips
-const int NUMBER_OF_FLIP_FLOP_ICS = pow(2, D_PINS_NUMBER);
-
-// The decoder input pins on the board.
-const int DECODER_INPUT_PINS[D_PINS_NUMBER] = {8, 9, 10};
-
-// The decoder enable pin on the board.
-const int DECODER_ENABLE_PIN = 11;
-
-// Enable pin low state
-const int DECODER_ENABLE_PIN_LOW_STATE = LOW;
-
-// Enable pin high state
-const int DECODER_ENABLE_PIN_HIGH_STATE = HIGH;
-
 // An array of lows to use to set all pins of the decoder to zero.
 int decoderZeroStates[D_PINS_NUMBER];
 

--- a/led-flipflop-extender/flipflop.ino
+++ b/led-flipflop-extender/flipflop.ino
@@ -1,9 +1,3 @@
-// The number of data pins of the flipflop IC.
-const int FLIPFLOP_PINS_NUMBER = 8;
-
-// The numbers of the flipflop data pins on the board.
-const int FLIPFLOP_DATA_PINS[FLIPFLOP_PINS_NUMBER] = {0, 1, 2, 3, 4, 5, 6, 7};
-
 // A constant array of lows to use to set all pins of the flipflop to zero.
 int flipFlopZeroStates[FLIPFLOP_PINS_NUMBER];
 

--- a/led-flipflop-extender/led-flipflop-extender.ino
+++ b/led-flipflop-extender/led-flipflop-extender.ino
@@ -1,7 +1,65 @@
 #include <SoftwareSerial.h>
 
+// The number of the decoder input pins.
+const int D_PINS_NUMBER = 3;
+
+// The number of flipFlop chips
+const int NUMBER_OF_FLIP_FLOP_ICS = pow(2, D_PINS_NUMBER);
+
+// The decoder input pins on the board.
+const int DECODER_INPUT_PINS[D_PINS_NUMBER] = {8, 9, 10};
+
+// The decoder enable pin on the board.
+const int DECODER_ENABLE_PIN = 11;
+
+// Enable pin low state
+const int DECODER_ENABLE_PIN_LOW_STATE = LOW;
+
+// Enable pin high state
+const int DECODER_ENABLE_PIN_HIGH_STATE = HIGH;
+
+// The number of data pins of the flipflop IC.
+const int FLIPFLOP_PINS_NUMBER = 8;
+
+// The numbers of the flipflop data pins on the board.
+const int FLIPFLOP_DATA_PINS[FLIPFLOP_PINS_NUMBER] = {0, 1, 2, 3, 4, 5, 6, 7};
+
 int debugLevel = 1;
 SoftwareSerial logSerial(14, 15);
+
+struct FlipFlopsStates {
+  int ledsStates[NUMBER_OF_FLIP_FLOP_ICS];
+  int period;
+};
+
+struct Sequence {
+  FlipFlopsStates *sequence;
+  int sequenceLength;
+  int statesCurrentIndex;
+  unsigned long statesNextEventTime;
+};
+
+int numberOfStates = 8;
+
+FlipFlopsStates *sequence1FlipFlopStates = new FlipFlopsStates[numberOfStates] {
+    {{1, 0, 1, 0, 1, 0, 1, 0}, 1000},
+    {{0, 1, 0, 1, 0, 1, 0, 1}, 1000},
+    {{1, 0, 1, 0, 1, 0, 1, 0}, 500},
+    {{0, 1, 0, 1, 0, 1, 0, 1}, 500},
+    {{1, 0, 1, 0, 1, 0, 1, 0}, 200},
+    {{0, 1, 0, 1, 0, 1, 0, 1}, 200},
+    {{1, 0, 1, 0, 1, 0, 1, 0}, 100},
+    {{0, 1, 0, 1, 0, 1, 0, 1}, 100}
+};
+
+Sequence sequence1 = {
+  sequence1FlipFlopStates,
+  numberOfStates,
+  0,
+  0
+};
+
+Sequence StaticStatesUpdate(Sequence sequence, int lastState = -1);
 
 void setup() {
   // put your setup code here, to run once:
@@ -11,9 +69,41 @@ void setup() {
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
-  FlipFlopWrite(1, 2);
-  delay(1);
-  FlipFlopWrite(0, 2);
-  delay(7);
+  sequence1 = StaticStatesUpdate(sequence1);
+}
+
+bool WriteState(int *states){
+  return WriteState(states, 0, NUMBER_OF_FLIP_FLOP_ICS);
+}
+
+bool WriteState(int *states, int numberOfICs){
+    return WriteState(states, 0, numberOfICs);
+}
+
+bool WriteState(int *states, int start, int numberOfICs){
+  for(int i = start; i < (start + numberOfICs); i++){
+    if (!FlipFlopWrite(states[i], i))
+      return false;
+  }
+}
+
+Sequence StaticStatesUpdate(Sequence sequence, int lastState = -1){
+  if(lastState < 0 || lastState >= sequence.sequenceLength){
+    lastState = sequence.sequenceLength - 1; 
+  }
+
+  unsigned long currentTime = millis();
+
+  if(currentTime >= sequence.statesNextEventTime){
+    WriteState(sequence.sequence[sequence.statesCurrentIndex].ledsStates);
+
+    sequence.statesNextEventTime = currentTime + sequence.sequence[sequence.statesCurrentIndex].period;
+
+    sequence.statesCurrentIndex++;
+    if(sequence.statesCurrentIndex > lastState){
+      sequence.statesCurrentIndex = 0;
+    }
+  }
+
+  return sequence;
 }


### PR DESCRIPTION
Added the support to do a static sequence of leds,
this was done by defining two structs:
 * `FlipFlopsStates`: which holds an array of ints representing the bits of all the flipflops, in addition to state `period` to determine how long must this state lasts.
 * `Sequence`: which holds the leds static sequence.

A static sequence is a predefined sequence of leds states, this can be useful in two scenarios:
 * In case you want to define the sequence manually before compile time.
 * In case the sequence is expected to be auto-generated by a third-party and received by the Arduino using any mean of communication.

fixes: #3 