### PR TITLE
Move sequence.Next before write states

### DIFF
--- a/led-flipflop-extender/led-flipflop-extender.ino
+++ b/led-flipflop-extender/led-flipflop-extender.ino
@@ -29,7 +29,7 @@ FlipFlopsStates<NUMBER_OF_FLIP_FLOP_ICS> *sequence1FlipFlopStates = new FlipFlop
 StaticSequence<NUMBER_OF_FLIP_FLOP_ICS> sequence1 =  StaticSequence<NUMBER_OF_FLIP_FLOP_ICS>(sequence1FlipFlopStates, numberOfStates);
 
 const int NUMBER_OF_STATES = 4;
-int unifiedDelay = 1000;
+int unifiedDelay = 20;
 int flipFlopRepetitiveStates[NUMBER_OF_STATES] = {0b00000001, 0b00000100, 0b00010000, 0b01000000};
 int flipFlopRepetitiveDelays[NUMBER_OF_STATES] = {unifiedDelay, unifiedDelay, unifiedDelay, unifiedDelay};
 
@@ -45,19 +45,19 @@ void setup() {
 }
 
 void loop() {
-  //StatesUpdate(sequence1);
-  StatesUpdate(sequence2, 4);
+  StatesUpdate(sequence1);
+  //StatesUpdate(sequence2, 4);
 }
 
 void StatesUpdate(Sequence<NUMBER_OF_FLIP_FLOP_ICS> &sequence, int lastState = -1){
   unsigned long currentTime = millis();
 
   if(currentTime >= sequence.statesNextEventTime){
-    WriteState(sequence.GetState().ledsStates);
+    sequence.Next(lastState);
 
     sequence.statesNextEventTime = currentTime + sequence.GetState().period;
 
-    sequence.Next(lastState);
+    WriteState(sequence.GetState().ledsStates);
   }
 }
 

--- a/led-flipflop-extender/src/Sequence/Sequence.h
+++ b/led-flipflop-extender/src/Sequence/Sequence.h
@@ -45,7 +45,7 @@ template <int ArraySize>
 StaticSequence<ArraySize>::StaticSequence(FlipFlopsStates<ArraySize> staticStates[], int _sequenceLength) {
     this->sequence = staticStates;
     this->sequenceLength = _sequenceLength;
-    this->statesCurrentIndex = 0;
+    this->statesCurrentIndex = -1;
     this->statesNextEventTime = 0;
 }
 
@@ -99,7 +99,7 @@ RepetitiveSequence<ArraySize>::RepetitiveSequence(int _sequence[], int _sequence
     this->sequenceLength = _sequenceLength;
     this->sequenceDelays = _delays;
     this->currentFlipFlopIndex = 0;
-    this->currentSequenceIndex = 0;
+    this->currentSequenceIndex = -1;
     this->statesNextEventTime = 0;
 
     this->currentState.ledsStates[currentFlipFlopIndex] = sequence[0];


### PR DESCRIPTION
Moved the `sequence.Next` function before the writeStates
function, this was done for the `sequence.currentState` to reflect
the current state and not the last state.

closes #12